### PR TITLE
Remove unused GET /notifications/{scan_id} endpoint

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -26,7 +26,6 @@ from src.db import (
     cache,
     channels,
     notification_log,
-    notify,
     subscribers,
     users,
 )
@@ -392,8 +391,9 @@ def create_subscriber(
     """Register a location + radius for fire alerts. Requires login.
 
     Every reload, freshly fetched detections within `radius_miles` of this
-    point get queued as a notification (see /notifications/{scan_id}), sent
-    to whichever channels you've registered on /manage-notifications.
+    point get queued as a notification and drained by the notifier service
+    (see src/notifier.py), sent to whichever channels you've registered on
+    /manage-notifications.
     """
     subscriber_id = subscribers.add_subscriber(
         owner=username,
@@ -489,16 +489,3 @@ def delete_channel(
             detail="No channel with that id owned by this account",
         )
     return {"status": "removed"}
-
-
-@api.get("/notifications/{scan_id}")
-def claim_notifications(
-    scan_id: str,
-    limit: int = 50,
-    username: str = CurrentUser,
-) -> list[dict[str, Any]]:
-    """Claim (retrieve + remove) up to `limit` pending location alerts for a
-    scan. Requires login. Meant for a notification worker to poll --
-    anything not claimed here stays queued for the next call.
-    """
-    return notify.claim_notifications(scan_id, limit=limit)


### PR DESCRIPTION
Confirmed via Jaeger tracing (queried the running `fire-map-web` container's recorded operations and did an explicit trace search) that this route has never been called in this deployment's lifetime. The actual consumer of `notify.claim_notifications` is `src/notifier.py`'s `drain_scan()`, which calls it directly in-process -- never over HTTP.

The route also had no ownership check: any logged-in user could claim (and atomically HGETDEL) any scan's queued notifications, since `scan_id` is discoverable via the unauthenticated `/scans`/`/history` endpoints. With no legitimate caller depending on it, removing it is lower-risk than scoping its auth.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)