### PR TITLE
Guard against concurrent duplicate cache reloads

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -57,3 +57,11 @@ HISTORY_AREA_CACHE_KEY_PREFIX = "firemap:history_area:"
 HISTORY_AREA_CACHE_TTL_SECONDS = int(
     os.environ.get("HISTORY_AREA_CACHE_TTL_SECONDS", str(UPDATE_INTERVAL_SECONDS))
 )
+
+# Guards against a cold/expired cache being reloaded more than once at a
+# time -- see update.reload_data_guarded. A plain SET NX, not a per-process
+# lock, since web can run as more than one process/container; the TTL is a
+# safety net so a holder that crashes mid-reload doesn't wedge every future
+# reload behind it forever.
+RELOAD_LOCK_KEY = "firemap:reload:lock"
+RELOAD_LOCK_TTL_SECONDS = int(os.environ.get("RELOAD_LOCK_TTL_SECONDS", "60"))

--- a/src/db/cache.py
+++ b/src/db/cache.py
@@ -17,7 +17,13 @@ from typing import Any, cast
 import valkey
 from geojson import Feature, FeatureCollection
 
-from . import CURRENT_CACHE_KEY, EVENT_KEY_PREFIX, UPDATE_INTERVAL_SECONDS, VALKEY_URL
+from . import (
+    CURRENT_CACHE_KEY,
+    EVENT_KEY_PREFIX,
+    RELOAD_LOCK_KEY,
+    UPDATE_INTERVAL_SECONDS,
+    VALKEY_URL,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +108,24 @@ def get_current() -> FeatureCollection | None:
     feature_collection = FeatureCollection(features)
     feature_collection["scan_id"] = index.get("scan_id")
     return feature_collection
+
+
+def acquire_reload_lock(ttl: int) -> bool:
+    """Try to claim the single "a reload is in flight" slot for `ttl`
+    seconds. True if this caller won it, False if someone else already
+    holds it.
+
+    A plain SET NX rather than a threading.Lock -- web can run as more than
+    one process/container, and only Valkey is shared across all of them.
+    """
+    return bool(get_client().set(RELOAD_LOCK_KEY, "1", nx=True, ex=ttl))
+
+
+def release_reload_lock() -> None:
+    """Release the reload-in-flight slot, if this caller (or anyone) holds
+    it. Safe to call even if the lock already expired on its own.
+    """
+    get_client().delete(RELOAD_LOCK_KEY)
 
 
 def get_cached_json(key: str) -> Any | None:

--- a/src/db/update.py
+++ b/src/db/update.py
@@ -1,14 +1,19 @@
 import logging
+import time
 import uuid
 
 from geojson import FeatureCollection
 
 from src.viirs.get_fire_data import get_fire_data
 
-from . import UPDATE_INTERVAL_SECONDS, cache, notify
+from . import RELOAD_LOCK_TTL_SECONDS, UPDATE_INTERVAL_SECONDS, cache, notify
 from .postgres import init_db, insert_detections
 
 logger = logging.getLogger(__name__)
+
+# How often to check whether an in-flight reload elsewhere has landed, while
+# waiting on it instead of duplicating it -- see reload_data_guarded.
+RELOAD_WAIT_POLL_SECONDS = 0.2
 
 
 def reload_data(ttl: int = UPDATE_INTERVAL_SECONDS) -> FeatureCollection:
@@ -44,6 +49,43 @@ def reload_data(ttl: int = UPDATE_INTERVAL_SECONDS) -> FeatureCollection:
 
     logger.info(f"Reload complete: {len(features)} detections ({scan_id=})")
     return feature_collection
+
+
+def reload_data_guarded(ttl: int = UPDATE_INTERVAL_SECONDS) -> FeatureCollection:
+    """Like reload_data, but only one reload actually runs at a time --
+    across every request, thread, and web process/container, not just this
+    one caller.
+
+    index()/current()/lifespan() in web/app.py each independently reload on
+    a cache miss with no coordination between them, and reload_data() does
+    a live FIRMS fetch plus Postgres/Valkey writes -- slow enough, and
+    blocking enough (network + DB I/O releases the GIL), that two requests
+    hitting a cold cache at once would otherwise both actually run it:
+    double the Postgres scan rows and, if FIRMS' response shifts between
+    the two live fetches, double the queued notifications too. A caller
+    that loses the race here waits for the winner's reload to land in the
+    cache instead.
+    """
+    if cache.acquire_reload_lock(RELOAD_LOCK_TTL_SECONDS):
+        try:
+            return reload_data(ttl=ttl)
+        finally:
+            cache.release_reload_lock()
+
+    logger.info("Reload already in progress elsewhere; waiting for it instead of duplicating it")
+    deadline = time.monotonic() + RELOAD_LOCK_TTL_SECONDS
+    while time.monotonic() < deadline:
+        cached = cache.get_current()
+        if cached is not None:
+            return cached
+        time.sleep(RELOAD_WAIT_POLL_SECONDS)
+
+    # The winner's reload didn't land before our own wait ran out (it's
+    # taking longer than RELOAD_LOCK_TTL_SECONDS, or it crashed after
+    # claiming the lock but before the TTL expired) -- fall back to doing
+    # it ourselves rather than serving nothing indefinitely.
+    logger.warning("Timed out waiting for in-flight reload; reloading directly")
+    return reload_data(ttl=ttl)
 
 
 if __name__ == "__main__":

--- a/web/app.py
+++ b/web/app.py
@@ -30,7 +30,7 @@ from src.db import (
     users,
 )
 from src.db.postgres import get_history, get_history_in_area, get_scans, init_db
-from src.db.update import reload_data
+from src.db.update import reload_data_guarded
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ async def lifespan(_app: fastapi.FastAPI) -> AsyncIterator[None]:
     notification_log.init_db()
     if cache.get_current() is None:
         logger.info("Cache empty on startup, running an initial reload")
-        reload_data()
+        reload_data_guarded()
     yield
 
 
@@ -155,7 +155,7 @@ def index(request: Request) -> HTMLResponse:
     feature_collection = cache.get_current()
 
     if feature_collection is None:
-        feature_collection = reload_data()
+        feature_collection = reload_data_guarded()
 
     confidences = get_confidence_breakdown(feature_collection["features"])
     scans = get_scans(limit=1)
@@ -254,8 +254,14 @@ def me(request: Request) -> dict[str, str | None]:
 
 @api.post("/reload")
 def reload() -> JSONResponse:
-    """Fetch fresh (global) data, persist it, and return the snapshot read back from Valkey."""
-    reload_data()
+    """Fetch fresh (global) data, persist it, and return the snapshot read back from Valkey.
+
+    Guarded the same way as the cache-miss reloads below -- if the
+    scheduler's interval and a manually-triggered reload land at the same
+    moment, this waits for whichever one is already in flight instead of
+    also running its own.
+    """
+    reload_data_guarded()
     return JSONResponse(cache.get_current())
 
 
@@ -265,7 +271,7 @@ def current() -> JSONResponse:
     feature_collection = cache.get_current()
 
     if feature_collection is None:
-        reload_data()
+        reload_data_guarded()
         feature_collection = cache.get_current()
 
     return JSONResponse(feature_collection)


### PR DESCRIPTION
index(), current(), lifespan(), and POST /reload each independently reload on a cache miss/manual trigger with no coordination between them. reload_data() does a live FIRMS fetch plus Postgres/Valkey writes -- slow and I/O-bound enough (network + DB calls release the GIL) that two requests hitting a cold cache at once could both actually run it: duplicate Postgres scan rows and, if FIRMS' response shifts between the two live fetches, duplicate queued notifications.

Adds `reload_data_guarded()`, backed by a Valkey `SET NX` lock (not a `threading.Lock` -- web can run as more than one process/container, and only Valkey is shared across them). A caller that loses the race waits for the winner's reload to land in the cache instead of duplicating it, falling back to reloading directly only if that wait times out.

Verified against a live Valkey instance: the lock correctly rejects a second concurrent acquire while held, and under a real threaded race `reload_data_guarded()` only actually invokes `reload_data()` once, with both callers returning the same result.

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)