### PR TITLE
Add city-alert radius matching and editable alert-area labels

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -48,3 +48,7 @@ run = "open http://localhost:16686"
 [tasks.notifier-logs]
 description = "Follow logs for the notifier service (Apprise sends, claim batches)"
 run = "docker compose logs -f notifier"
+
+[tasks.load-cities]
+description = "Download GeoNames' cities500 dump and load it into the cities table (nearest-town lookups)"
+run = "fnox exec -- docker compose exec web uv run python -m src.db.cities"

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -65,3 +65,34 @@ HISTORY_AREA_CACHE_TTL_SECONDS = int(
 # reload behind it forever.
 RELOAD_LOCK_KEY = "firemap:reload:lock"
 RELOAD_LOCK_TTL_SECONDS = int(os.environ.get("RELOAD_LOCK_TTL_SECONDS", "60"))
+
+# A detection farther than this from the nearest row in `cities` isn't
+# considered "near" any town -- open ocean, deep wilderness, etc. -- so it's
+# labeled/cached as such rather than tagged with whatever city happened to
+# be least-far-away.
+NEAREST_TOWN_MAX_DISTANCE_MILES = float(os.environ.get("NEAREST_TOWN_MAX_DISTANCE_MILES", "50"))
+
+# Namespaces the cached result of a city-name search (see cities.py's
+# search_cities and the /towns/search route) -- keyed on the query text
+# itself, which repeats heavily: every viewer typing a common prefix
+# ("spr...") hits the same cache entry, and the same person's own
+# keystrokes re-search shrinking/growing prefixes of what they already
+# typed.
+TOWN_SEARCH_CACHE_KEY_PREFIX = "firemap:town_search:"
+
+# The `cities` table only changes when someone reruns the `load-cities`
+# mise task (see cities.py's load_geonames) -- nothing in the normal
+# request/reload cycle touches it -- so search results can sit far longer
+# than the detection-freshness caches above without ever going stale in a
+# way that matters. Defaults to a day; override if you're actively
+# reloading the dataset and want to see it reflected sooner.
+TOWN_SEARCH_CACHE_TTL_SECONDS = int(
+    os.environ.get("TOWN_SEARCH_CACHE_TTL_SECONDS", str(24 * 60 * 60))
+)
+
+# Namespaces the cached result of a city's full detection history (see
+# city_history.py and the /towns/{geoname_id}/history route) -- unlike the
+# search cache above, this table grows every reload, so it uses the same
+# reload-bound TTL as HISTORY_AREA_CACHE_TTL_SECONDS (just its own prefix,
+# since the two cache different queries against different tables).
+TOWN_HISTORY_CACHE_KEY_PREFIX = "firemap:town_history:"

--- a/src/db/cities.py
+++ b/src/db/cities.py
@@ -1,0 +1,267 @@
+"""Postgres storage for towns/cities, used to label a raw (lat, lon) fire
+detection with the nearest place name.
+
+Loaded from a GeoNames (https://www.geonames.org/) cities dump rather than
+queried live against an external geocoder -- the lookup happens once per
+matched detection (see notify.py), and a local table with a PostGIS index
+answers that in one query with no network round-trip, no rate limit, and no
+API key to manage. Loading the dataset is a separate, explicit step (see
+load_geonames / the `load-cities` mise task) -- it's a one-time ~30MB
+download, not something every app startup should trigger.
+"""
+
+import csv
+import logging
+import zipfile
+from collections.abc import Iterable
+from io import BytesIO, TextIOWrapper
+from typing import Any
+
+import httpx
+from psycopg.rows import dict_row
+
+from . import NEAREST_TOWN_MAX_DISTANCE_MILES
+from .postgres import MILES_TO_METERS, get_pool
+
+logger = logging.getLogger(__name__)
+
+# cities500 (population >= 500) rather than cities5000/cities15000 -- "local
+# towns", not just major cities, is the point. Override via env if a
+# smaller/larger dump is preferred.
+DEFAULT_GEONAMES_URL = "https://download.geonames.org/export/dump/cities500.zip"
+
+# Needed for the geography column + KNN query below, same as
+# fire_detections' own `geom` column (see postgres.py).
+SCHEMA = """
+CREATE EXTENSION IF NOT EXISTS postgis;
+-- Lets search_cities fall back to fuzzy (trigram) matching, so a
+-- misspelled search ("Sprinfield") still finds "Springfield" instead of
+-- coming back empty the way a pure prefix match would.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- levenshtein() below, used alongside pg_trgm to rank search_cities'
+-- results -- trigram similarity alone is noisy for short names (see that
+-- function's docstring), and plain edit distance is exactly the metric
+-- that's actually reliable there.
+CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+CREATE TABLE IF NOT EXISTS cities (
+    geoname_id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL,
+    country_code TEXT,
+    admin1_code TEXT,
+    population BIGINT,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL
+);
+ALTER TABLE cities ADD COLUMN IF NOT EXISTS geom GEOGRAPHY(Point, 4326)
+    GENERATED ALWAYS AS (ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography) STORED;
+CREATE INDEX IF NOT EXISTS idx_cities_geom ON cities USING GIST (geom);
+-- Backs search_cities' prefix match -- text_pattern_ops (rather than the
+-- default btree opclass) is what actually lets a `LIKE 'foo%'` query use
+-- this index; a plain btree index on lower(name) only helps equality
+-- lookups. Kept alongside the trigram index below: a correct prefix still
+-- gets the fast, exact-ranked path, while pg_trgm only has to cover the
+-- fuzzy/misspelled fallback.
+CREATE INDEX IF NOT EXISTS idx_cities_name_lower ON cities (lower(name) text_pattern_ops);
+-- Backs search_cities' trigram fallback (the `<%` word-similarity operator
+-- and `word_similarity()` ordering below) -- GIN over GiST since this
+-- index is read-heavy and rarely written to (only ever rebuilt by
+-- load_geonames). gin_trgm_ops covers word_similarity's operators the same
+-- way it covers plain similarity's.
+CREATE INDEX IF NOT EXISTS idx_cities_name_trgm ON cities USING GIN (name gin_trgm_ops);
+"""
+
+UPSERT = """
+INSERT INTO cities (geoname_id, name, country_code, admin1_code, population, latitude, longitude)
+VALUES (%(geoname_id)s, %(name)s, %(country_code)s, %(admin1_code)s, %(population)s,
+        %(latitude)s, %(longitude)s)
+ON CONFLICT (geoname_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    country_code = EXCLUDED.country_code,
+    admin1_code = EXCLUDED.admin1_code,
+    population = EXCLUDED.population,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude;
+"""
+
+# Nearest neighbor via the `<->` KNN operator, which (unlike ST_DWithin's
+# ST_Distance ordering) can actually use the GIST index -- fine here since
+# this table is much smaller than fire_detections, but there's no reason not
+# to use the same trick. The row still comes back with its real distance so
+# the caller can reject it if it's farther than NEAREST_TOWN_MAX_DISTANCE_MILES.
+NEAREST_CITY_QUERY = """
+SELECT
+    geoname_id, name, country_code, admin1_code, population, latitude, longitude,
+    ST_Distance(geom, ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s), 4326)::geography)
+        / %(meters_per_mile)s AS distance_miles
+FROM cities
+ORDER BY geom <-> ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s), 4326)::geography
+LIMIT 1;
+"""
+
+
+def init_db() -> None:
+    """Create the cities table if it doesn't already exist. Doesn't load
+    any data -- see load_geonames for that.
+    """
+    logger.info("Ensuring cities table exists")
+    with get_pool().connection() as conn:
+        conn.execute(SCHEMA)
+
+
+def _parse_geonames_rows(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
+    """Parse GeoNames' tab-delimited cities dump into rows for `cities`.
+
+    Columns (see https://download.geonames.org/export/dump/readme.txt):
+    geonameid, name, asciiname, alternatenames, latitude, longitude,
+    feature class, feature code, country code, cc2, admin1 code, admin2
+    code, admin3 code, admin4 code, population, elevation, dem, timezone,
+    modification date. Only the columns this app actually uses are kept.
+    """
+    reader = csv.reader(lines, delimiter="\t")
+    for row in reader:
+        if len(row) < 15:
+            continue
+        yield {
+            "geoname_id": int(row[0]),
+            "name": row[1],
+            "latitude": float(row[4]),
+            "longitude": float(row[5]),
+            "country_code": row[8] or None,
+            "admin1_code": row[10] or None,
+            "population": int(row[14]) if row[14] else None,
+        }
+
+
+def load_geonames(url: str = DEFAULT_GEONAMES_URL, batch_size: int = 5000) -> int:
+    """Download a GeoNames cities dump and upsert every row into `cities`.
+
+    Safe to rerun -- ON CONFLICT (geoname_id) DO UPDATE means a later run
+    with a fresher dump just refreshes names/populations in place, it
+    doesn't duplicate rows.
+    """
+    logger.info(f"Downloading GeoNames cities dump from {url}")
+    response = httpx.get(url, timeout=120, follow_redirects=True)
+    response.raise_for_status()
+
+    with zipfile.ZipFile(BytesIO(response.content)) as archive:
+        # The dump's one .txt member shares the zip's own basename.
+        (name,) = [n for n in archive.namelist() if n.endswith(".txt")]
+        with archive.open(name) as raw:
+            lines = TextIOWrapper(raw, encoding="utf-8")
+
+            total = 0
+            batch: list[dict[str, Any]] = []
+            with get_pool().connection() as conn:
+                for city_row in _parse_geonames_rows(lines):
+                    batch.append(city_row)
+                    if len(batch) >= batch_size:
+                        with conn.cursor() as cur:
+                            cur.executemany(UPSERT, batch)
+                        conn.commit()
+                        total += len(batch)
+                        logger.info(f"Loaded {total} cities so far")
+                        batch = []
+
+                if batch:
+                    with conn.cursor() as cur:
+                        cur.executemany(UPSERT, batch)
+                    conn.commit()
+                    total += len(batch)
+
+    logger.info(f"Loaded {total} cities from {url}")
+    return total
+
+
+def nearest_city(
+    latitude: float,
+    longitude: float,
+    max_distance_miles: float = NEAREST_TOWN_MAX_DISTANCE_MILES,
+) -> dict[str, Any] | None:
+    """The closest row in `cities` to (latitude, longitude), or None if
+    either the table is empty or the closest row is farther than
+    `max_distance_miles` away (open ocean, remote wilderness, etc.).
+    """
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            NEAREST_CITY_QUERY,
+            {"lat": latitude, "lon": longitude, "meters_per_mile": MILES_TO_METERS},
+        )
+        row = cur.fetchone()
+
+    if row is None or row["distance_miles"] > max_distance_miles:
+        return None
+    return row
+
+
+def search_cities(query: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Cities matching `query`, best match first -- backs the city-alert
+    subscribe form's and the map's search boxes, so someone can find
+    "Springfield" without already knowing its geoname_id.
+
+    Candidates come from either of two match modes:
+      - a plain prefix match (fast, via idx_cities_name_lower) -- keeps the
+        common case (someone correctly typing the start of a real name)
+        ranked first and exact, the same as before this had any fuzzy
+        matching at all;
+      - a trigram *word* similarity match (pg_trgm's `<%` operator, via
+        idx_cities_name_trgm) -- catches everything a strict prefix would
+        miss, most importantly a misspelling ("Sprinfield" still finds
+        "Springfield").
+
+    Ranking a surviving candidate is a separate question from matching it,
+    and needs a different metric: word_similarity scores the query against
+    whichever word-boundary substring of `name` matches best, which is
+    great for a short query against a longer multi-word name ("New Yrok"
+    still finds "New York City") but is *noisy* for a name close to the
+    query's own length -- a handful of shared trigrams is a bigger fraction
+    of a short name's total, so trigram scoring systematically over-ranks
+    obscure short names ("Alta", "Anta") over the actual likely target
+    ("Atlanta") for a query like "Altanta". Plain edit distance
+    (levenshtein, normalized into a 0-1 score by string length) doesn't
+    have that bias and is exactly the right metric for that same-length
+    case. Neither metric is reliable on its own across both shapes of
+    match, so every candidate is scored by whichever of the two rates it
+    higher, and the result sorts by that.
+
+    Ordered prefix-matches-first, then by that composite score, then by
+    population as the final tiebreaker. Empty list for a blank query
+    rather than the whole table.
+    """
+    query = query.strip()
+    if not query:
+        return []
+
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        # pg_trgm's own default for the `<%` operator (0.6) is tuned for
+        # longer documents and is too strict for short city names -- at
+        # that default, a plain one-letter typo like "Atlnta" scores 0.5
+        # and gets filtered out before ORDER BY ever sees it. Lowered to
+        # match plain similarity's own threshold (0.3), which is what
+        # actually lets the misspellings this function exists for surface
+        # at all. Session-scoped (not LOCAL/transaction-scoped) since
+        # every caller through this pool wants the same lowered threshold.
+        cur.execute("SET pg_trgm.word_similarity_threshold = 0.3")
+        cur.execute(
+            "SELECT geoname_id, name, country_code, admin1_code, population, "
+            "latitude, longitude, "
+            "GREATEST("
+            "1 - levenshtein(lower(name), lower(%(query)s))::float "
+            "/ greatest(length(name), length(%(query)s)), "
+            "word_similarity(%(query)s, name)"
+            ") AS score "
+            "FROM cities "
+            "WHERE lower(name) LIKE lower(%(prefix)s) OR %(query)s <%% name "
+            "ORDER BY (lower(name) LIKE lower(%(prefix)s)) DESC, "
+            "score DESC, population DESC NULLS LAST "
+            "LIMIT %(limit)s",
+            {"query": query, "prefix": f"{query}%", "limit": limit},
+        )
+        return cur.fetchall()
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    init_db()
+    load_geonames(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_GEONAMES_URL)

--- a/src/db/city_history.py
+++ b/src/db/city_history.py
@@ -1,0 +1,133 @@
+"""Postgres storage for the full history of fire detections near each city.
+
+Every scan, notify.py resolves each detection's nearest city
+(cities.nearest_city) and records it here -- unconditionally, regardless of
+whether that detection happened to match any subscriber -- so this is the
+durable "what's this city been dealing with" log behind
+/towns/{geoname_id}/history, not just the detections that triggered an
+alert for someone.
+
+This is deliberately a plain Postgres table, not a Valkey cache with a
+TTL: the whole point is a *full* history that keeps growing, the same way
+fire_detections does for the whole map, rather than a rolling window that
+forgets anything older than a few days.
+"""
+
+import logging
+import uuid
+from typing import Any
+
+from geojson import Feature
+from psycopg.rows import dict_row
+
+from .postgres import get_pool
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS city_fire_history (
+    id BIGSERIAL PRIMARY KEY,
+    geoname_id BIGINT NOT NULL REFERENCES cities(geoname_id) ON DELETE CASCADE,
+    scan_id UUID NOT NULL,
+    detection_key TEXT NOT NULL,
+    distance_miles DOUBLE PRECISION NOT NULL,
+    detected_at TIMESTAMPTZ NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    frp DOUBLE PRECISION,
+    confidence TEXT,
+    satellite TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_city_fire_history_city
+    ON city_fire_history (geoname_id, detected_at DESC);
+-- Same rationale as notification_log's dedup index -- FIRMS' rolling
+-- window can hand back the same physical detection across several
+-- consecutive reloads before it ages out (see cache.py's event_id); a
+-- city's history should show it once, not once per reload it was still in
+-- that window.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_city_fire_history_dedup
+    ON city_fire_history (geoname_id, detection_key);
+"""
+
+INSERT = """
+INSERT INTO city_fire_history (
+    geoname_id, scan_id, detection_key, distance_miles, detected_at,
+    latitude, longitude, frp, confidence, satellite
+) VALUES (
+    %(geoname_id)s, %(scan_id)s, %(detection_key)s, %(distance_miles)s, %(detected_at)s,
+    %(latitude)s, %(longitude)s, %(frp)s, %(confidence)s, %(satellite)s
+)
+ON CONFLICT (geoname_id, detection_key) DO NOTHING;
+"""
+
+
+def init_db() -> None:
+    """Create the city_fire_history table if it doesn't already exist.
+
+    Depends on the cities table already existing (FK) -- call
+    cities.init_db() first.
+    """
+    logger.info("Ensuring city_fire_history table exists")
+    with get_pool().connection() as conn:
+        conn.execute(SCHEMA)
+
+
+def record_detection(
+    town: dict[str, Any],
+    feature: Feature,
+    scan_id: uuid.UUID | str,
+    distance_miles: float,
+    detection_key: str,
+) -> None:
+    """Log one detection against `town`'s history.
+
+    `town` is a row from cities.nearest_city -- only its geoname_id is used
+    here. Idempotent: ON CONFLICT DO NOTHING against (geoname_id,
+    detection_key) means calling this again for a detection FIRMS keeps
+    handing back across later reloads just no-ops.
+    """
+    props = feature["properties"]
+    longitude, latitude = feature["geometry"]["coordinates"]
+    with get_pool().connection() as conn:
+        conn.execute(
+            INSERT,
+            {
+                "geoname_id": town["geoname_id"],
+                "scan_id": str(scan_id),
+                "detection_key": detection_key,
+                "distance_miles": round(distance_miles, 1),
+                "detected_at": props["datetime"],
+                "latitude": latitude,
+                "longitude": longitude,
+                "frp": props.get("frp"),
+                "confidence": props.get("confidence"),
+                "satellite": props.get("satellite"),
+            },
+        )
+        conn.commit()
+
+
+def get_history(
+    geoname_id: int, limit: int = 500, since: str | None = None
+) -> list[dict[str, Any]]:
+    """Full history of detections logged near this city, most recent first.
+
+    Not windowed by any TTL -- see the module docstring. Empty (not an
+    error) once nothing's ever been logged for this geoname_id, whether or
+    not it's actually a real one.
+    """
+    clauses = ["geoname_id = %(geoname_id)s"]
+    params: dict[str, Any] = {"geoname_id": geoname_id, "limit": limit}
+    if since:
+        clauses.append("detected_at >= %(since)s")
+        params["since"] = since
+
+    query = (
+        "SELECT * FROM city_fire_history WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY detected_at DESC LIMIT %(limit)s"
+    )
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(query, params)
+        return cur.fetchall()

--- a/src/db/city_subscribers.py
+++ b/src/db/city_subscribers.py
@@ -1,0 +1,221 @@
+"""Postgres storage for city-based fire alert subscriptions.
+
+Alongside subscribers.py's point + radius subscriptions, this lets someone
+subscribe to a whole city (a row in `cities`, see cities.py) instead of a
+hand-picked point. By default this is matched in notify.py by comparing a
+detection's resolved nearest city (cities.nearest_city) against this
+table's geoname_id -- no radius, just "this city". Setting `radius_miles`
+switches that subscription to matching by distance from the city's own
+point instead (same as subscribers.py), which also catches detections
+whose nearest city resolved to somewhere else nearby.
+
+Kept as its own table (rather than folding into subscribers) since the two
+have genuinely different shapes -- one keys off a point, the other off a
+geoname_id -- and different match logic in notify.py. `subscriptions_view`
+below is where they're brought back together for callers (notification_log,
+/manage) that just want "everything this owner has configured" without
+caring which kind.
+"""
+
+import logging
+from typing import Any
+
+from psycopg.rows import dict_row
+
+from .postgres import get_pool
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS city_subscribers (
+    id BIGSERIAL PRIMARY KEY,
+    owner TEXT NOT NULL,
+    contact TEXT NOT NULL,
+    geoname_id BIGINT NOT NULL REFERENCES cities(geoname_id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- One subscription per (owner, city) -- re-subscribing to the same city
+-- just refreshes contact/radius (see the upsert below) instead of piling
+-- up duplicate rows that'd all match and queue separately.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_city_subscribers_owner_city
+    ON city_subscribers (owner, geoname_id);
+-- NULL (the default) keeps the original "exact nearest-city" match; set
+-- to switch this subscription to distance-from-city-center matching
+-- instead -- see notify.py's queue_notifications.
+ALTER TABLE city_subscribers ADD COLUMN IF NOT EXISTS radius_miles DOUBLE PRECISION;
+
+-- Unifies subscribers (point + radius) and city_subscribers (whole city
+-- or city + radius) into one read shape -- /manage's combined listing and
+-- notification_log's owner-scoping join use this instead of querying both
+-- tables and merging in Python. Re-created (not just CREATE IF NOT
+-- EXISTS) so a rerun always reflects the latest column set here.
+CREATE OR REPLACE VIEW subscriptions_view AS
+SELECT
+    s.id, 'point'::text AS kind, s.owner, s.contact,
+    s.latitude, s.longitude, s.radius_miles,
+    NULL::bigint AS geoname_id, NULL::text AS city_name, s.created_at
+FROM subscribers s
+UNION ALL
+SELECT
+    cs.id, 'city'::text AS kind, cs.owner, cs.contact,
+    c.latitude, c.longitude, cs.radius_miles,
+    cs.geoname_id, c.name AS city_name, cs.created_at
+FROM city_subscribers cs
+JOIN cities c ON c.geoname_id = cs.geoname_id;
+"""
+
+UPSERT = """
+INSERT INTO city_subscribers (owner, contact, geoname_id, radius_miles)
+VALUES (%(owner)s, %(contact)s, %(geoname_id)s, %(radius_miles)s)
+ON CONFLICT (owner, geoname_id) DO UPDATE
+    SET contact = EXCLUDED.contact, radius_miles = EXCLUDED.radius_miles
+RETURNING id;
+"""
+
+
+def init_db() -> None:
+    """Create the city_subscribers table and subscriptions_view.
+
+    Depends on subscribers and cities already existing (the view joins
+    both, and the FK needs cities) -- call subscribers.init_db() and
+    cities.init_db() first.
+    """
+    logger.info("Ensuring city_subscribers table exists")
+    with get_pool().connection() as conn:
+        conn.execute(SCHEMA)
+
+
+def add_subscriber(
+    owner: str,
+    contact: str,
+    geoname_id: int,
+    radius_miles: float | None = None,
+) -> int:
+    """Register (or refresh) a subscription to `geoname_id`, returning its id.
+
+    `owner` is the logged-in username that created it (see users.py) --
+    only that user can cancel it later. `radius_miles` left as None (the
+    default) matches only detections whose resolved nearest city is this
+    one; set it to match by distance from the city's own point instead
+    (see notify.py).
+    """
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                UPSERT,
+                {
+                    "owner": owner,
+                    "contact": contact,
+                    "geoname_id": geoname_id,
+                    "radius_miles": radius_miles,
+                },
+            )
+            row = cur.fetchone()
+        conn.commit()
+
+    assert row is not None  # INSERT ... RETURNING id always returns a row
+    logger.info(
+        f"Added city subscriber {row[0]} (geoname_id={geoname_id}, "
+        f"radius_miles={radius_miles}, owner={owner!r})"
+    )
+    return row[0]
+
+
+def get_subscribers() -> list[dict[str, Any]]:
+    """List every active city subscription, across every owner, with the
+    city's own point joined in.
+
+    Used internally for matching (see notify.py) -- not exposed over the
+    API as-is, since that would leak every subscriber's contact info to
+    every logged-in user. See `get_subscribers_by_owner` for the
+    per-account view /city-subscribers/mine uses.
+
+    The join (rather than a bare `SELECT *`) is what lets notify.py match
+    a radius-based city subscription by distance from `latitude`/
+    `longitude` without a second lookup per subscriber.
+    """
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT cs.*, c.latitude, c.longitude, c.name AS city_name "
+            "FROM city_subscribers cs JOIN cities c ON c.geoname_id = cs.geoname_id"
+        )
+        return cur.fetchall()
+
+
+def get_subscribers_by_owner(owner: str) -> list[dict[str, Any]]:
+    """List only the city subscriptions created by `owner`, with the city's
+    name/admin1/country joined in so the UI doesn't need a second lookup
+    per row.
+    """
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT cs.id, cs.owner, cs.contact, cs.geoname_id, cs.radius_miles, cs.created_at, "
+            "c.name AS city_name, c.admin1_code, c.country_code "
+            "FROM city_subscribers cs JOIN cities c ON c.geoname_id = cs.geoname_id "
+            "WHERE cs.owner = %(owner)s ORDER BY cs.created_at DESC",
+            {"owner": owner},
+        )
+        return cur.fetchall()
+
+
+def get_subscriber(subscriber_id: int, owner: str) -> dict[str, Any] | None:
+    """Fetch one city subscription, scoped to `owner` the same way
+    get_subscribers_by_owner is -- None if it doesn't exist or belongs to
+    someone else.
+    """
+    with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT * FROM city_subscribers WHERE id = %(id)s AND owner = %(owner)s",
+            {"id": subscriber_id, "owner": owner},
+        )
+        return cur.fetchone()
+
+
+def set_contact(subscriber_id: int, owner: str, contact: str) -> bool:
+    """Rename the label on a city subscription. Returns False if no
+    matching subscription was owned by `owner` (either it doesn't exist or
+    belongs to someone else).
+    """
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE city_subscribers SET contact = %(contact)s "
+                "WHERE id = %(id)s AND owner = %(owner)s",
+                {"contact": contact, "id": subscriber_id, "owner": owner},
+            )
+            updated = cur.rowcount > 0
+        conn.commit()
+    return updated
+
+
+def set_radius(subscriber_id: int, owner: str, radius_miles: float | None) -> bool:
+    """Set (or clear, with radius_miles=None) the match radius on a city
+    subscription. Clearing it reverts to matching only the exact
+    nearest-city case. Returns False if no matching subscription was owned
+    by `owner` (either it doesn't exist or belongs to someone else).
+    """
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE city_subscribers SET radius_miles = %(radius_miles)s "
+                "WHERE id = %(id)s AND owner = %(owner)s",
+                {"radius_miles": radius_miles, "id": subscriber_id, "owner": owner},
+            )
+            updated = cur.rowcount > 0
+        conn.commit()
+    return updated
+
+
+def remove_subscriber(subscriber_id: int, owner: str) -> bool:
+    """Cancel a city subscription. Returns False if no matching subscription
+    was owned by `owner` (either it doesn't exist or belongs to someone else).
+    """
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM city_subscribers WHERE id = %(id)s AND owner = %(owner)s",
+                {"id": subscriber_id, "owner": owner},
+            )
+            removed = cur.rowcount > 0
+        conn.commit()
+    return removed

--- a/src/db/notification_log.py
+++ b/src/db/notification_log.py
@@ -11,9 +11,18 @@ queue_notifications and notifier.py's drain_scan.
 It also doubles as the dedup log: FIRMS' rolling window can return the same
 physical detection (same point, same acquisition time, same satellite --
 see cache.py's event_id) across several consecutive reloads before it ages
-out. `log_queued`'s ON CONFLICT DO NOTHING against (subscriber_id,
-detection_key) means a detection only ever queues a notification once per
-subscriber, no matter how many more times FIRMS keeps handing it back.
+out. `log_queued`'s ON CONFLICT DO NOTHING against (subscription_kind,
+subscriber_id, detection_key) means a detection only ever queues a
+notification once per subscription, no matter how many more times FIRMS
+keeps handing it back.
+
+`subscriber_id` alone isn't a stable reference -- notify.py matches two
+kinds of subscription (point + radius, in subscribers.py, and whole-city,
+in city_subscribers.py) that each have their own id sequence starting at 1,
+so `subscription_kind` disambiguates which table an id came from. That
+also means there's no DB-level FK on subscriber_id here (it can point to
+either table); ownership is instead checked by joining subscriptions_view
+(see city_subscribers.py), which already knows how to route by kind.
 """
 
 import logging
@@ -47,18 +56,29 @@ CREATE INDEX IF NOT EXISTS idx_notification_events_subscriber
 -- unique index below, via its WHERE clause) since there's nothing
 -- meaningful to backfill them with.
 ALTER TABLE notification_events ADD COLUMN IF NOT EXISTS detection_key TEXT NOT NULL DEFAULT '';
+-- Added alongside city subscriptions -- subscriber_id's id sequence is
+-- shared between two different tables now (subscribers, city_subscribers),
+-- so this says which one. Existing rows predate city subscriptions and are
+-- backfilled as 'point'. The FK above only ever pointed at subscribers, so
+-- it's dropped here rather than trying to make it conditional on kind.
+ALTER TABLE notification_events ADD COLUMN IF NOT EXISTS subscription_kind TEXT
+    NOT NULL DEFAULT 'point';
+ALTER TABLE notification_events DROP CONSTRAINT IF EXISTS notification_events_subscriber_id_fkey;
+DROP INDEX IF EXISTS idx_notification_events_dedup;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_events_dedup
-    ON notification_events (subscriber_id, detection_key) WHERE detection_key <> '';
+    ON notification_events (subscription_kind, subscriber_id, detection_key)
+    WHERE detection_key <> '';
 """
 
 INSERT = """
 INSERT INTO notification_events (
-    subscriber_id, scan_id, distance_miles, detected_at, latitude, longitude, detection_key
+    subscriber_id, subscription_kind, scan_id, distance_miles, detected_at,
+    latitude, longitude, detection_key
 ) VALUES (
-    %(subscriber_id)s, %(scan_id)s, %(distance_miles)s, %(detected_at)s,
-    %(latitude)s, %(longitude)s, %(detection_key)s
+    %(subscriber_id)s, %(subscription_kind)s, %(scan_id)s, %(distance_miles)s,
+    %(detected_at)s, %(latitude)s, %(longitude)s, %(detection_key)s
 )
-ON CONFLICT (subscriber_id, detection_key) WHERE detection_key <> '' DO NOTHING
+ON CONFLICT (subscription_kind, subscriber_id, detection_key) WHERE detection_key <> '' DO NOTHING
 RETURNING id;
 """
 
@@ -76,16 +96,16 @@ def init_db() -> None:
 
 def log_queued(scan_id: uuid.UUID | str, matches: list[dict[str, Any]]) -> list[int | None]:
     """Record one row per queued match, in the same order as `matches` --
-    except a match whose (subscriber_id, detection_key) has already been
-    logged before (any prior scan, not just this one), which logs nothing
-    and comes back as None in that position instead.
+    except a match whose (subscription_kind, subscriber_id, detection_key)
+    has already been logged before (any prior scan, not just this one),
+    which logs nothing and comes back as None in that position instead.
 
-    Each match needs subscriber_id, distance_miles, detected_at, latitude,
-    longitude, detection_key. The caller drops any None-paired match
-    entirely rather than queuing it to Valkey -- that's the actual dedup
-    enforcement point, this just detects it. Non-None ids get stitched back
-    into their Valkey payload (as `event_id`) so the notifier can update
-    the right row later.
+    Each match needs subscription_kind, subscriber_id, distance_miles,
+    detected_at, latitude, longitude, detection_key. The caller drops any
+    None-paired match entirely rather than queuing it to Valkey -- that's
+    the actual dedup enforcement point, this just detects it. Non-None ids
+    get stitched back into their Valkey payload (as `event_id`) so the
+    notifier can update the right row later.
     """
     if not matches:
         return []
@@ -93,6 +113,7 @@ def log_queued(scan_id: uuid.UUID | str, matches: list[dict[str, Any]]) -> list[
     rows = [
         {
             "subscriber_id": match["subscriber_id"],
+            "subscription_kind": match["subscription_kind"],
             "scan_id": str(scan_id),
             "distance_miles": match["distance_miles"],
             "detected_at": match["detected_at"],
@@ -168,18 +189,24 @@ def mark_no_channels(event_ids: list[int]) -> None:
 
 
 def get_events_by_owner(owner: str, limit: int = 200) -> list[dict[str, Any]]:
-    """List recent trigger events for every subscription `owner` has,
-    newest first -- the history behind /manage's "how have my areas
-    triggered" view.
+    """List recent trigger events for every subscription `owner` has --
+    point or city alike -- newest first. The history behind /manage's "how
+    have my areas triggered" view.
+
+    Joined against subscriptions_view (see city_subscribers.py) rather than
+    subscribers directly, since subscriber_id's id sequence is shared
+    between two tables now -- the join has to match on (kind, id) together,
+    which subscriptions_view already knows how to do.
     """
     with get_pool().connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
-            "SELECT ne.id, ne.subscriber_id, ne.scan_id, ne.distance_miles, "
-            "ne.detected_at, ne.latitude, ne.longitude, ne.status, "
+            "SELECT ne.id, ne.subscriber_id, ne.subscription_kind, ne.scan_id, "
+            "ne.distance_miles, ne.detected_at, ne.latitude, ne.longitude, ne.status, "
             "ne.channels_delivered, ne.created_at "
             "FROM notification_events ne "
-            "JOIN subscribers s ON s.id = ne.subscriber_id "
-            "WHERE s.owner = %(owner)s "
+            "JOIN subscriptions_view sv "
+            "ON sv.kind = ne.subscription_kind AND sv.id = ne.subscriber_id "
+            "WHERE sv.owner = %(owner)s "
             "ORDER BY ne.created_at DESC "
             "LIMIT %(limit)s",
             {"owner": owner, "limit": limit},

--- a/src/db/notify.py
+++ b/src/db/notify.py
@@ -18,6 +18,12 @@ also what dedup checks against: FIRMS' rolling window can keep handing back
 the same physical detection across several consecutive reloads before it
 ages out, and a subscriber should hear about it once, not once per reload
 it happens to still be in that window.
+
+Two kinds of subscription are matched here: point + radius (subscribers.py)
+and whole-city (city_subscribers.py) -- see queue_notifications for how each
+is matched, and notification_log's `subscription_kind` column for how the
+two are told apart downstream (their ids come from separate tables, so
+`subscriber_id` alone doesn't disambiguate).
 """
 
 import json
@@ -30,8 +36,16 @@ from typing import Any, cast
 import valkey.exceptions
 from geojson import Feature
 
-from . import NOTIFY_KEY_PREFIX, NOTIFY_SCAN_QUEUE_KEY, notification_log, subscribers
+from . import (
+    NOTIFY_KEY_PREFIX,
+    NOTIFY_SCAN_QUEUE_KEY,
+    city_history,
+    city_subscribers,
+    notification_log,
+    subscribers,
+)
 from .cache import event_id, get_client
+from .cities import nearest_city
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +70,9 @@ def queue_notifications(
     radius. Returns the number queued.
     """
     features = list(features)
-    subs = subscribers.get_subscribers()
-    if not subs:
+    point_subs = subscribers.get_subscribers()
+    city_subs = city_subscribers.get_subscribers()
+    if not point_subs and not city_subs:
         logger.info(f"No subscribers registered, nothing to match for scan {scan_id}")
         return 0
 
@@ -69,13 +84,38 @@ def queue_notifications(
         # once per feature (not per subscriber match) since it only
         # depends on the detection itself.
         detection_key = event_id(feature)
-        for sub in subs:
+
+        # Resolved once per detection regardless of whether it matches any
+        # subscriber -- unlike the old subscriber-gated lookup this
+        # replaced, city_fire_history is meant to be a *full* history of
+        # what's landed near a city, not just what happened to trigger an
+        # alert for someone.
+        town: dict[str, Any] | None = None
+        try:
+            town = nearest_city(lat, lon)
+        except Exception:
+            # cities table might not exist/be loaded yet -- a missing town
+            # label shouldn't stop the alert itself.
+            logger.exception(f"Nearest-city lookup failed for {lat}, {lon}")
+
+        if town is not None:
+            try:
+                city_history.record_detection(
+                    town, feature, scan_id, town["distance_miles"], detection_key
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to record detection near {town['name']!r} in city history"
+                )
+
+        for sub in point_subs:
             distance = distance_miles(lat, lon, sub["latitude"], sub["longitude"])
             if distance > sub["radius_miles"]:
                 continue
 
             matches.append(
                 {
+                    "subscription_kind": "point",
                     "subscriber_id": sub["id"],
                     "owner": sub["owner"],
                     "contact": sub["contact"],
@@ -85,6 +125,7 @@ def queue_notifications(
                     "longitude": lon,
                     "feature": feature,
                     "detection_key": detection_key,
+                    "town": town,
                     # The alert area's own center/radius -- included so a
                     # batched message covering several of an owner's areas
                     # (see notifier.py:build_batch_message) can label which
@@ -95,19 +136,52 @@ def queue_notifications(
                 }
             )
 
+        # A city subscription with no radius_miles set matches only the
+        # exact nearest-city case (same as what /towns/{geoname_id}/history
+        # shows); one with a radius matches by distance from the city's own
+        # point instead, same as a point subscription, so it isn't limited
+        # to detections whose nearest city happens to resolve to this one.
+        for sub in city_subs:
+            if sub["radius_miles"] is not None:
+                distance = distance_miles(lat, lon, sub["latitude"], sub["longitude"])
+                if distance > sub["radius_miles"]:
+                    continue
+            else:
+                if town is None or sub["geoname_id"] != town["geoname_id"]:
+                    continue
+                distance = town["distance_miles"]
+
+            matches.append(
+                {
+                    "subscription_kind": "city",
+                    "subscriber_id": sub["id"],
+                    "owner": sub["owner"],
+                    "contact": sub["contact"],
+                    "distance_miles": round(distance, 1),
+                    "detected_at": feature["properties"]["datetime"],
+                    "latitude": lat,
+                    "longitude": lon,
+                    "feature": feature,
+                    "detection_key": detection_key,
+                    "town": town,
+                }
+            )
+
     if not matches:
         logger.info(
             f"No subscriber matches for scan {scan_id} "
-            f"({len(features)} detection(s), {len(subs)} subscriber(s))"
+            f"({len(features)} detection(s), {len(point_subs)} point + "
+            f"{len(city_subs)} city subscriber(s))"
         )
         return 0
 
     # Durably logged before the ephemeral Valkey queue -- each row_id rides
     # along in its match's payload (as event_id) so the notifier can update
     # this same row once it knows whether the send actually went out. A
-    # match whose (subscriber_id, detection_key) was already logged in some
-    # earlier scan comes back None here -- that's the dedup check, and it's
-    # dropped entirely rather than queued again (see log_queued).
+    # match whose (subscription_kind, subscriber_id, detection_key) was
+    # already logged in some earlier scan comes back None here -- that's
+    # the dedup check, and it's dropped entirely rather than queued again
+    # (see log_queued).
     row_ids = notification_log.log_queued(scan_id, matches)
     skipped = sum(1 for row_id in row_ids if row_id is None)
 
@@ -116,7 +190,8 @@ def queue_notifications(
         if row_id is None:
             continue
         field = (
-            f"notification:{match['subscriber_id']}:{match['detected_at']}"
+            f"notification:{match['subscription_kind']}:{match['subscriber_id']}"
+            f":{match['detected_at']}"
             f":{match['latitude']:.4f}:{match['longitude']:.4f}"
         )
         pending[field] = json.dumps({**match, "event_id": row_id})

--- a/src/db/subscribers.py
+++ b/src/db/subscribers.py
@@ -113,6 +113,23 @@ def get_subscriber(subscriber_id: int, owner: str) -> dict[str, Any] | None:
         return cur.fetchone()
 
 
+def set_contact(subscriber_id: int, owner: str, contact: str) -> bool:
+    """Rename the label on a subscription. Returns False if no matching
+    subscription was owned by `owner` (either it doesn't exist or belongs
+    to someone else).
+    """
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE subscribers SET contact = %(contact)s "
+                "WHERE id = %(id)s AND owner = %(owner)s",
+                {"contact": contact, "id": subscriber_id, "owner": owner},
+            )
+            updated = cur.rowcount > 0
+        conn.commit()
+    return updated
+
+
 def remove_subscriber(subscriber_id: int, owner: str) -> bool:
     """Cancel a subscription. Returns False if no matching subscription was
     owned by `owner` (either it doesn't exist or belongs to someone else).

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -60,23 +60,54 @@ def maps_link(lat: float, lon: float) -> str:
     return f"https://www.google.com/maps?q={lat:.4f},{lon:.4f}"
 
 
+def town_label(notification: dict[str, Any]) -> str | None:
+    """'Springfield, IL, US' for a notification with a resolved nearest
+    town (see notify.queue_notifications), or None if the detection was too
+    far from anything in the cities table to label (see cities.nearest_city).
+    """
+    town = notification.get("town")
+    if town is None:
+        return None
+    parts = [town["name"]]
+    parts.extend(part for part in (town.get("admin1_code"), town.get("country_code")) if part)
+    return ", ".join(parts)
+
+
 def group_by_area(
     notifications: list[dict[str, Any]],
 ) -> list[list[dict[str, Any]]]:
-    """Split one recipient's notifications by alert area (subscriber_id),
-    each sorted by distance -- an owner with more than one area would
-    otherwise see one flattened list mixing distances relative to
-    different centers (0.2 mi from one area, 90 mi from another, with no
-    indication which area either number is relative to).
+    """Split one recipient's notifications by alert area, each sorted by
+    distance -- an owner with more than one area would otherwise see one
+    flattened list mixing distances relative to different centers (0.2 mi
+    from one area, 90 mi from another, with no indication which area either
+    number is relative to).
+
+    Keyed on (subscription_kind, subscriber_id), not subscriber_id alone --
+    point and city subscriptions each have their own id sequence starting
+    at 1, so a bare id could collide across kinds.
     """
-    by_area: dict[int, list[dict[str, Any]]] = {}
+    by_area: dict[tuple[str, int], list[dict[str, Any]]] = {}
     for notification in notifications:
-        by_area.setdefault(notification["subscriber_id"], []).append(notification)
+        key = (notification["subscription_kind"], notification["subscriber_id"])
+        by_area.setdefault(key, []).append(notification)
 
     groups = list(by_area.values())
     for group in groups:
         group.sort(key=lambda n: n["distance_miles"])
     return groups
+
+
+def area_header(area: dict[str, Any]) -> str:
+    """'Within 25 mi of 33.7, -84.4' for a point subscription, or 'Near
+    Springfield, IL, US' for a city one -- the label at the top of each
+    group in a batched alert (see render_html/render_markdown).
+    """
+    if area["subscription_kind"] == "city":
+        return f"Near {town_label(area) or 'your subscribed city'}"
+    return (
+        f"Within {area['sub_radius_miles']:g} mi of "
+        f"{area['sub_latitude']:.4f}, {area['sub_longitude']:.4f}"
+    )
 
 
 def build_title(notifications: list[dict[str, Any]]) -> str:
@@ -93,10 +124,7 @@ def render_html(notifications: list[dict[str, Any]]) -> str:
     sections = []
     for group in group_by_area(notifications):
         area = group[0]
-        header = (
-            f"<p><strong>Within {area['sub_radius_miles']:g} mi of "
-            f"{area['sub_latitude']:.4f}, {area['sub_longitude']:.4f}</strong></p>"
-        )
+        header = f"<p><strong>{html.escape(area_header(area))}</strong></p>"
 
         items = []
         for notification in group:
@@ -104,10 +132,12 @@ def render_html(notifications: list[dict[str, Any]]) -> str:
             props = feature["properties"]
             lon, lat = feature["geometry"]["coordinates"]
             satellite = html.escape(str(props.get("satellite", "unknown")))
+            town = town_label(notification)
+            near = f"near {html.escape(town)} " if town else ""
             items.append(
                 "<li>"
                 f"<strong>{notification['distance_miles']} mi away</strong> &mdash; "
-                f'<a href="{maps_link(lat, lon)}">{lat:.4f}, {lon:.4f}</a>, '
+                f'{near}<a href="{maps_link(lat, lon)}">{lat:.4f}, {lon:.4f}</a>, '
                 f"detected {format_detected_at(props.get('datetime', ''))} "
                 f"(satellite: {satellite})"
                 "</li>"
@@ -132,17 +162,16 @@ def render_markdown(notifications: list[dict[str, Any]]) -> str:
     sections = []
     for group in group_by_area(notifications):
         area = group[0]
-        lines = [
-            f"**Within {area['sub_radius_miles']:g} mi of "
-            f"{area['sub_latitude']:.4f}, {area['sub_longitude']:.4f}**"
-        ]
+        lines = [f"**{area_header(area)}**"]
         for notification in group:
             feature = notification["feature"]
             props = feature["properties"]
             lon, lat = feature["geometry"]["coordinates"]
+            town = town_label(notification)
+            near = f"near {town} " if town else ""
             lines.append(
                 f"- **{notification['distance_miles']} mi away** — "
-                f"[{lat:.4f}, {lon:.4f}]({maps_link(lat, lon)}), "
+                f"{near}[{lat:.4f}, {lon:.4f}]({maps_link(lat, lon)}), "
                 f"detected {format_detected_at(props.get('datetime', ''))} "
                 f"(satellite: {props.get('satellite', 'unknown')})"
             )

--- a/web/app.py
+++ b/web/app.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 import dotenv
 import fastapi
+import psycopg
 from fastapi import Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -23,8 +24,14 @@ from src.db import (
     DEFAULT_ALERT_RADIUS_MILES,
     HISTORY_AREA_CACHE_KEY_PREFIX,
     HISTORY_AREA_CACHE_TTL_SECONDS,
+    TOWN_HISTORY_CACHE_KEY_PREFIX,
+    TOWN_SEARCH_CACHE_KEY_PREFIX,
+    TOWN_SEARCH_CACHE_TTL_SECONDS,
     cache,
     channels,
+    cities,
+    city_history,
+    city_subscribers,
     notification_log,
     subscribers,
     users,
@@ -51,6 +58,14 @@ async def lifespan(_app: fastapi.FastAPI) -> AsyncIterator[None]:
     subscribers.init_db()
     users.init_db()
     channels.init_db()
+    # Table only -- doesn't load any rows. See the `load-cities` mise task
+    # (src/db/cities.py:load_geonames) for the one-time dataset load.
+    cities.init_db()
+    # Depends on subscribers and cities already existing (FK + the view it
+    # creates joins both) -- must come after both.
+    city_subscribers.init_db()
+    # Depends on cities already existing (FK).
+    city_history.init_db()
     # Depends on subscribers' table already existing (FK) -- must come after.
     notification_log.init_db()
     if cache.get_current() is None:
@@ -317,6 +332,193 @@ def history_area(
     return get_history_in_area(latitude=lat, longitude=lon, radius_miles=radius_miles, limit=limit)
 
 
+@api.get("/towns/nearest")
+def towns_nearest(
+    lat: float = fastapi.Query(..., ge=-90, le=90),
+    lon: float = fastapi.Query(..., ge=-180, le=180),
+) -> dict[str, Any]:
+    """The nearest town/city to a point, from the GeoNames-loaded `cities`
+    table (see src/db/cities.py) -- 404s if nothing's within
+    NEAREST_TOWN_MAX_DISTANCE_MILES (open ocean, remote wilderness, or the
+    dataset hasn't been loaded yet).
+    """
+    town = cities.nearest_city(lat, lon)
+    if town is None:
+        raise fastapi.HTTPException(status_code=404, detail="No town found near that point")
+    return town
+
+
+@api.get("/towns/search")
+def towns_search(
+    q: str = fastapi.Query(..., min_length=1, max_length=100),
+    limit: int = fastapi.Query(10, gt=0, le=50),
+) -> list[dict[str, Any]]:
+    """Cities whose name starts with `q`, largest population first -- backs
+    the city-alert subscribe form's and the map's search boxes (see
+    src/db/cities.py's search_cities).
+
+    Cached in Valkey, keyed on the exact (q, limit) pair -- search-as-you-
+    type means the same prefix gets re-queried constantly, both by the same
+    person (shrinking/growing what they've typed) and across everyone else
+    typing the same common city names, against a table that barely ever
+    changes (see TOWN_SEARCH_CACHE_TTL_SECONDS).
+    """
+    cache_key = f"{TOWN_SEARCH_CACHE_KEY_PREFIX}{q.lower()}:{limit}"
+    cached = cache.get_cached_json(cache_key)
+    if cached is not None:
+        return cached
+
+    results = cities.search_cities(q, limit=limit)
+    cache.set_cached_json(cache_key, results, ttl=TOWN_SEARCH_CACHE_TTL_SECONDS)
+    return results
+
+
+@api.get("/towns/{geoname_id}/history")
+def towns_history(
+    geoname_id: int, limit: int = 500, since: str | None = None
+) -> list[dict[str, Any]]:
+    """The full history of fire detections logged near this city (see
+    src/db/city_history.py) -- every detection that ever resolved to this
+    city as its nearest town, not just ones that happened to trigger an
+    alert for someone. Empty (not 404) once nothing's ever been logged for
+    this geoname_id, whether or not the id itself is real.
+
+    Cached the same way /subscribers/{id}/history is -- a fixed id repeats
+    across page loads (map searches, /manage's city-alert history button),
+    and the underlying table only grows between scheduled reloads, so
+    there's no point re-querying Postgres more often than that.
+    """
+    cache_key = f"{TOWN_HISTORY_CACHE_KEY_PREFIX}{geoname_id}:{limit}:{since or ''}"
+    cached = cache.get_cached_json(cache_key)
+    if cached is not None:
+        return cached
+
+    rows = city_history.get_history(geoname_id, limit=limit, since=since)
+    encoded = jsonable_encoder(rows)
+    cache.set_cached_json(cache_key, encoded, ttl=HISTORY_AREA_CACHE_TTL_SECONDS)
+    return encoded
+
+
+class SubscriptionLabelRequest(BaseModel):
+    label: str = Field(
+        ..., min_length=1, max_length=256, description="New label for this alert area."
+    )
+
+
+class CityRadiusRequest(BaseModel):
+    # None clears it, reverting to exact nearest-city matching -- unlike
+    # SubscriptionLabelRequest.label there's no way to "unset" a point
+    # subscription's radius, but a city one can meaningfully go either way.
+    radius_miles: float | None = Field(
+        None,
+        gt=0,
+        le=500,
+        description="New match radius in miles, or omit/null to revert to exact-city matching.",
+    )
+
+
+class CitySubscriptionRequest(BaseModel):
+    # Same free-text-label convention as SubscriptionRequest.contact below.
+    contact: str | None = Field(
+        None, description="Optional label for this subscription. Defaults to your username."
+    )
+    geoname_id: int = Field(..., description="A geoname_id from /towns/search or /towns/nearest.")
+    # Left unset (the default) to keep the original "exact nearest-city"
+    # match; set it to match by distance from the city's own point instead
+    # -- see city_subscribers.add_subscriber and notify.py.
+    radius_miles: float | None = Field(
+        None,
+        gt=0,
+        le=500,
+        description="Optional match radius (miles) around the city's point. "
+        "Omit to match only detections whose nearest city is this one.",
+    )
+
+
+@api.post("/city-subscribers")
+def create_city_subscriber(
+    payload: CitySubscriptionRequest,
+    username: str = CurrentUser,
+) -> dict[str, Any]:
+    """Subscribe to a whole city for fire alerts. Requires login.
+
+    Every reload, freshly fetched detections whose resolved nearest city
+    (see src/db/cities.py) is this one get queued as a notification, the
+    same as a point + radius subscription but matched by city instead of
+    distance.
+    """
+    try:
+        subscriber_id = city_subscribers.add_subscriber(
+            owner=username,
+            contact=payload.contact or username,
+            geoname_id=payload.geoname_id,
+            radius_miles=payload.radius_miles,
+        )
+    except psycopg.errors.ForeignKeyViolation as exc:
+        # geoname_id doesn't exist in `cities` -- most likely a stale value
+        # from /towns/search, or the dataset hasn't been loaded yet.
+        raise fastapi.HTTPException(status_code=404, detail="No city with that geoname_id") from exc
+    return {"id": subscriber_id}
+
+
+@api.get("/city-subscribers/mine")
+def list_my_city_subscribers(username: str = CurrentUser) -> list[dict[str, Any]]:
+    """List only the city subscriptions you own. Requires login."""
+    return city_subscribers.get_subscribers_by_owner(username)
+
+
+@api.patch("/city-subscribers/{subscriber_id}/label")
+def set_city_subscriber_label(
+    subscriber_id: int,
+    payload: SubscriptionLabelRequest,
+    username: str = CurrentUser,
+) -> dict[str, str]:
+    """Rename a city alert you own. Requires login."""
+    updated = city_subscribers.set_contact(subscriber_id, owner=username, contact=payload.label)
+    if not updated:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No city subscription with that id owned by this account",
+        )
+    return {"status": "updated", "label": payload.label}
+
+
+@api.patch("/city-subscribers/{subscriber_id}/radius")
+def set_city_subscriber_radius(
+    subscriber_id: int,
+    payload: CityRadiusRequest,
+    username: str = CurrentUser,
+) -> dict[str, Any]:
+    """Set or clear the match radius on a city alert you own. Requires
+    login. Clearing it (radius_miles omitted/null) reverts to matching
+    only detections whose nearest city is this one.
+    """
+    updated = city_subscribers.set_radius(
+        subscriber_id, owner=username, radius_miles=payload.radius_miles
+    )
+    if not updated:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No city subscription with that id owned by this account",
+        )
+    return {"status": "updated", "radius_miles": payload.radius_miles}
+
+
+@api.delete("/city-subscribers/{subscriber_id}")
+def delete_city_subscriber(
+    subscriber_id: int,
+    username: str = CurrentUser,
+) -> dict[str, str]:
+    """Cancel a city subscription you own. Requires login."""
+    removed = city_subscribers.remove_subscriber(subscriber_id, owner=username)
+    if not removed:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No city subscription with that id owned by this account",
+        )
+    return {"status": "removed"}
+
+
 def _subscriber_history_cache_key(subscriber_id: int) -> str:
     return f"{HISTORY_AREA_CACHE_KEY_PREFIX}subscriber:{subscriber_id}"
 
@@ -415,6 +617,22 @@ def create_subscriber(
 def list_my_subscribers(username: str = CurrentUser) -> list[dict[str, Any]]:
     """List only the subscriptions you own. Requires login."""
     return subscribers.get_subscribers_by_owner(username)
+
+
+@api.patch("/subscribers/{subscriber_id}/label")
+def set_subscriber_label(
+    subscriber_id: int,
+    payload: SubscriptionLabelRequest,
+    username: str = CurrentUser,
+) -> dict[str, str]:
+    """Rename an alert area you own. Requires login."""
+    updated = subscribers.set_contact(subscriber_id, owner=username, contact=payload.label)
+    if not updated:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No subscription with that id owned by this account",
+        )
+    return {"status": "updated", "label": payload.label}
 
 
 @api.delete("/subscribers/{subscriber_id}")

--- a/web/templates/manage.html
+++ b/web/templates/manage.html
@@ -31,6 +31,32 @@
             <ul id="subscription-history-list"></ul>
         </div>
 
+        <h3>Your city alerts</h3>
+        <p id="city-manage-status"></p>
+        <table id="city-subscriptions-table" style="display: none">
+            <thead>
+                <tr>
+                    <th>Label</th>
+                    <th>City</th>
+                    <th>Radius (mi)</th>
+                    <th>Created</th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody id="city-subscriptions-body"></tbody>
+        </table>
+        <div id="city-subscription-history" style="display: none">
+            <h4 id="city-subscription-history-title"></h4>
+            <p>
+                Every detection whose nearest city ever resolved to this one
+                shows up here &mdash; the full history, not just the ones
+                that triggered an alert for you.
+            </p>
+            <p id="city-subscription-history-status"></p>
+            <ul id="city-subscription-history-list"></ul>
+        </div>
+
         <h3>Recent triggers</h3>
         <p>
             Every time a reload finds a detection inside one of your areas, it
@@ -70,6 +96,9 @@
     .status-failed { background: #fbeaea; color: #c22a2a; }
     .status-no_channels { background: #fdf3e3; color: #a6650a; }
     .status-queued { background: #eef1f4; color: #606c76; }
+
+    .area-label-input { width: 10rem; }
+    .area-label-status { margin-left: 0.4rem; font-size: 0.85rem; color: #606c76; }
 </style>
 
 <script>
@@ -80,16 +109,147 @@
         queued: 'Queued'
     };
 
-    // Keyed by subscriber id so the trigger table can show a short label
-    // (rather than a bare id) for which area each event belongs to.
-    var subscribersById = {};
+    // Keyed by "<kind>:<id>" (not a bare id) since point and city
+    // subscriptions each have their own id sequence starting at 1 -- a
+    // bare id would collide between the two.
+    var subscriptionsByKey = {};
 
-    function areaLabel(subscriberId) {
-        var sub = subscribersById[subscriberId];
+    function subscriptionKey(kind, id) {
+        return kind + ':' + id;
+    }
+
+    function areaLabel(kind, id) {
+        var sub = subscriptionsByKey[subscriptionKey(kind, id)];
         if (!sub) {
-            return 'Area #' + subscriberId;
+            return (kind === 'city' ? 'City' : 'Area') + ' #' + id;
+        }
+        if (kind === 'city') {
+            return [sub.city_name, sub.admin1_code, sub.country_code].filter(Boolean).join(', ');
         }
         return sub.latitude.toFixed(3) + ', ' + sub.longitude.toFixed(3) + ' (' + sub.radius_miles + ' mi)';
+    }
+
+    // Builds an editable "Label" <td> backed by PATCH /subscribers/{id}/label
+    // or /city-subscribers/{id}/label -- saved on blur/Enter, and skipped
+    // entirely if the value didn't actually change since the last save.
+    function buildLabelCell(kind, sub) {
+        var cell = document.createElement('td');
+
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.value = sub.contact || '';
+        input.maxLength = 256;
+        input.className = 'area-label-input';
+
+        var status = document.createElement('span');
+        status.className = 'area-label-status';
+        status.dataset.lastSaved = sub.contact || '';
+
+        var save = function () {
+            var label = input.value.trim();
+            if (!label || label === status.dataset.lastSaved) {
+                input.value = status.dataset.lastSaved;
+                return;
+            }
+            status.textContent = 'Saving…';
+            var path = (kind === 'city' ? '/city-subscribers/' : '/subscribers/') + sub.id + '/label';
+            fetch(path, {
+                method: 'PATCH',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ label: label })
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        return response.json().then(function (body) {
+                            throw new Error(body.detail || ('Request failed: ' + response.status));
+                        });
+                    }
+                    return response.json();
+                })
+                .then(function () {
+                    sub.contact = label;
+                    status.dataset.lastSaved = label;
+                    status.textContent = 'Saved';
+                    setTimeout(function () { status.textContent = ''; }, 1500);
+                })
+                .catch(function (err) {
+                    status.textContent = 'Could not save: ' + err.message;
+                });
+        };
+        input.addEventListener('blur', save);
+        input.addEventListener('keydown', function (evt) {
+            if (evt.key === 'Enter') {
+                input.blur();
+            }
+        });
+
+        cell.appendChild(input);
+        cell.appendChild(status);
+        return cell;
+    }
+
+    // Builds an editable "Radius" <td> for a city subscription, backed by
+    // PATCH /city-subscribers/{id}/radius -- an empty value clears it
+    // (reverting to exact nearest-city matching), same save-on-blur/Enter
+    // and skip-if-unchanged behavior as buildLabelCell.
+    function buildCityRadiusCell(sub) {
+        var cell = document.createElement('td');
+
+        var input = document.createElement('input');
+        input.type = 'number';
+        input.step = 'any';
+        input.min = '1';
+        input.max = '500';
+        input.placeholder = 'Exact city only';
+        input.value = sub.radius_miles == null ? '' : sub.radius_miles;
+        input.className = 'area-label-input';
+
+        var status = document.createElement('span');
+        status.className = 'area-label-status';
+        status.dataset.lastSaved = sub.radius_miles == null ? '' : String(sub.radius_miles);
+
+        var save = function () {
+            var raw = input.value.trim();
+            if (raw === status.dataset.lastSaved) {
+                return;
+            }
+            var radiusMiles = raw ? parseFloat(raw) : null;
+            status.textContent = 'Saving…';
+            fetch('/city-subscribers/' + sub.id + '/radius', {
+                method: 'PATCH',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ radius_miles: radiusMiles })
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        return response.json().then(function (body) {
+                            throw new Error(body.detail || ('Request failed: ' + response.status));
+                        });
+                    }
+                    return response.json();
+                })
+                .then(function () {
+                    sub.radius_miles = radiusMiles;
+                    status.dataset.lastSaved = raw;
+                    status.textContent = 'Saved';
+                    setTimeout(function () { status.textContent = ''; }, 1500);
+                })
+                .catch(function (err) {
+                    status.textContent = 'Could not save: ' + err.message;
+                });
+        };
+        input.addEventListener('blur', save);
+        input.addEventListener('keydown', function (evt) {
+            if (evt.key === 'Enter') {
+                input.blur();
+            }
+        });
+
+        cell.appendChild(input);
+        cell.appendChild(status);
+        return cell;
     }
 
     function renderSubscriptions(subs) {
@@ -97,8 +257,7 @@
         var body = document.getElementById('subscriptions-body');
         body.innerHTML = '';
 
-        subscribersById = {};
-        subs.forEach(function (sub) { subscribersById[sub.id] = sub; });
+        subs.forEach(function (sub) { subscriptionsByKey[subscriptionKey('point', sub.id)] = sub; });
 
         if (!subs.length) {
             table.style.display = 'none';
@@ -110,7 +269,9 @@
         subs.forEach(function (sub) {
             var row = document.createElement('tr');
 
-            [sub.contact, sub.latitude, sub.longitude, sub.radius_miles, sub.created_at].forEach(function (value) {
+            row.appendChild(buildLabelCell('point', sub));
+
+            [sub.latitude, sub.longitude, sub.radius_miles, sub.created_at].forEach(function (value) {
                 var cell = document.createElement('td');
                 cell.textContent = value;
                 row.appendChild(cell);
@@ -138,6 +299,59 @@
         });
     }
 
+    function renderCitySubscriptions(subs) {
+        var table = document.getElementById('city-subscriptions-table');
+        var body = document.getElementById('city-subscriptions-body');
+        body.innerHTML = '';
+
+        subs.forEach(function (sub) { subscriptionsByKey[subscriptionKey('city', sub.id)] = sub; });
+
+        if (!subs.length) {
+            table.style.display = 'none';
+            document.getElementById('city-manage-status').textContent = 'No city alerts yet.';
+            return;
+        }
+
+        table.style.display = '';
+        document.getElementById('city-manage-status').textContent = '';
+
+        subs.forEach(function (sub) {
+            var row = document.createElement('tr');
+
+            row.appendChild(buildLabelCell('city', sub));
+
+            var cityCell = document.createElement('td');
+            cityCell.textContent = areaLabel('city', sub.id);
+            row.appendChild(cityCell);
+
+            row.appendChild(buildCityRadiusCell(sub));
+
+            var createdCell = document.createElement('td');
+            createdCell.textContent = sub.created_at;
+            row.appendChild(createdCell);
+
+            var historyCell = document.createElement('td');
+            var historyButton = document.createElement('button');
+            historyButton.textContent = 'History';
+            historyButton.addEventListener('click', function () {
+                loadCitySubscriptionHistory(sub);
+            });
+            historyCell.appendChild(historyButton);
+            row.appendChild(historyCell);
+
+            var actionCell = document.createElement('td');
+            var cancelButton = document.createElement('button');
+            cancelButton.textContent = 'Cancel';
+            cancelButton.addEventListener('click', function () {
+                cancelCitySubscription(sub.id);
+            });
+            actionCell.appendChild(cancelButton);
+            row.appendChild(actionCell);
+
+            body.appendChild(row);
+        });
+    }
+
     function renderEvents(events) {
         var table = document.getElementById('events-table');
         var body = document.getElementById('events-body');
@@ -156,7 +370,7 @@
             var row = document.createElement('tr');
 
             [
-                areaLabel(event.subscriber_id),
+                areaLabel(event.subscription_kind, event.subscriber_id),
                 event.distance_miles,
                 event.detected_at,
             ].forEach(function (value) {
@@ -220,7 +434,7 @@
         var list = document.getElementById('subscription-history-list');
 
         container.style.display = '';
-        title.textContent = 'History near ' + areaLabel(sub.id);
+        title.textContent = 'History near ' + areaLabel('point', sub.id);
         status.textContent = 'Loading…';
         list.innerHTML = '';
 
@@ -250,6 +464,94 @@
             })
             .catch(function (err) {
                 status.textContent = 'Could not load history: ' + err.message;
+            });
+    }
+
+    function loadCitySubscriptions() {
+        var status = document.getElementById('city-manage-status');
+        status.textContent = 'Loading…';
+
+        return fetch('/city-subscribers/mine', { credentials: 'same-origin' })
+            .then(function (response) {
+                if (!response.ok) {
+                    return response.json().then(function (body) {
+                        throw new Error(body.detail || ('Request failed: ' + response.status));
+                    });
+                }
+                return response.json();
+            })
+            .then(function (subs) {
+                status.textContent = '';
+                renderCitySubscriptions(subs);
+            })
+            .catch(function (err) {
+                document.getElementById('city-subscriptions-table').style.display = 'none';
+                status.textContent = 'Could not load city alerts: ' + err.message;
+            });
+    }
+
+    // Backed by /towns/{geoname_id}/history -- the *full* history for this
+    // city (see src/db/city_history.py), not windowed to a recent past like
+    // /subscribers/{id}/history above.
+    function loadCitySubscriptionHistory(sub) {
+        var container = document.getElementById('city-subscription-history');
+        var title = document.getElementById('city-subscription-history-title');
+        var status = document.getElementById('city-subscription-history-status');
+        var list = document.getElementById('city-subscription-history-list');
+
+        container.style.display = '';
+        title.textContent = 'History for ' + areaLabel('city', sub.id);
+        status.textContent = 'Loading…';
+        list.innerHTML = '';
+
+        fetch('/towns/' + sub.geoname_id + '/history', { credentials: 'same-origin' })
+            .then(function (response) {
+                if (!response.ok) {
+                    return response.json().then(function (body) {
+                        throw new Error(body.detail || ('Request failed: ' + response.status));
+                    });
+                }
+                return response.json();
+            })
+            .then(function (rows) {
+                if (!rows.length) {
+                    status.textContent = 'No detections logged for this city yet.';
+                    return;
+                }
+                status.textContent = rows.length + ' detection(s) logged for this city:';
+                rows.forEach(function (row) {
+                    var item = document.createElement('li');
+                    item.textContent = (
+                        row.distance_miles.toFixed(1) + ' mi from center — ' +
+                        (row.confidence || 'unknown') + ' confidence, detected ' + row.detected_at
+                    );
+                    list.appendChild(item);
+                });
+            })
+            .catch(function (err) {
+                status.textContent = 'Could not load history: ' + err.message;
+            });
+    }
+
+    function cancelCitySubscription(id) {
+        var status = document.getElementById('city-manage-status');
+        status.textContent = 'Cancelling…';
+
+        fetch('/city-subscribers/' + id, {
+            method: 'DELETE',
+            credentials: 'same-origin'
+        })
+            .then(function (response) {
+                if (!response.ok) {
+                    return response.json().then(function (body) {
+                        throw new Error(body.detail || ('Request failed: ' + response.status));
+                    });
+                }
+                status.textContent = 'Cancelled.';
+                loadCitySubscriptions();
+            })
+            .catch(function (err) {
+                status.textContent = 'Could not cancel that city alert: ' + err.message;
             });
     }
 
@@ -297,17 +599,15 @@
             });
     }
 
-    // Logged-in state comes from the session cookie set by /login. Areas
-    // load first since the trigger table's area labels depend on them.
-    fetch('/me', { credentials: 'same-origin' })
-        .then(function (response) { return response.json(); })
-        .then(function (data) {
-            if (!data.username) {
-                document.getElementById('manage-logged-out').style.display = '';
-                return;
-            }
-            document.getElementById('manage-logged-in').style.display = '';
-            loadSubscriptions().then(loadEvents);
-        });
+    // Logged-in state is already known server-side (see manage_page in
+    // web/app.py) -- no need to round-trip to /me just to ask again. Both
+    // kinds of area load first since the trigger table's area labels
+    // depend on them.
+    if ({{ current_user | tojson }}) {
+        document.getElementById('manage-logged-in').style.display = '';
+        Promise.all([loadSubscriptions(), loadCitySubscriptions()]).then(loadEvents);
+    } else {
+        document.getElementById('manage-logged-out').style.display = '';
+    }
 </script>
 {% endblock %}

--- a/web/templates/manage_notifications.html
+++ b/web/templates/manage_notifications.html
@@ -152,18 +152,16 @@
             });
     }
 
-    // Logged-in state comes from the session cookie set by /login.
-    fetch('/me', { credentials: 'same-origin' })
-        .then(function (response) { return response.json(); })
-        .then(function (data) {
-            if (data.username) {
-                document.getElementById('account-logged-in').style.display = '';
-                updateAddressField();
-                loadChannels();
-            } else {
-                document.getElementById('account-logged-out').style.display = '';
-            }
-        });
+    // Logged-in state is already known server-side (see
+    // manage_notifications_page in web/app.py) -- no need to round-trip to
+    // /me just to ask again.
+    if ({{ current_user | tojson }}) {
+        document.getElementById('account-logged-in').style.display = '';
+        updateAddressField();
+        loadChannels();
+    } else {
+        document.getElementById('account-logged-out').style.display = '';
+    }
 
     document.getElementById('channel-type').addEventListener('change', updateAddressField);
 

--- a/web/templates/map.html
+++ b/web/templates/map.html
@@ -70,6 +70,38 @@
     .history-popup {
         font-size: 1.2rem;
     }
+
+    #map-search {
+        position: relative;
+    }
+
+    #map-search-input {
+        width: 16rem;
+    }
+
+    #map-search-results {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000;
+        width: 16rem;
+        background: #fff;
+        border: 0.1rem solid #e1e1e1;
+        max-height: 12rem;
+        overflow-y: auto;
+    }
+
+    #map-search-results li {
+        padding: 0.3rem 0.6rem;
+        cursor: pointer;
+    }
+
+    #map-search-results li:hover {
+        background: #eef1f4;
+    }
 </style>
 <script type="text/javascript">
     function InitMap()
@@ -225,15 +257,11 @@
             return hot;
         }
 
-        // Fetched once up front so both the marker popups below and the
-        // empty-map popup (further down) can tell, by the time anyone
-        // actually clicks something, whether to show the subscribe form or
-        // a login prompt -- built lazily per popup rather than once at
-        // startup, since this hasn't necessarily resolved yet at that point.
-        var currentUsername = null;
-        fetch('/me', { credentials: 'same-origin' })
-            .then(function (response) { return response.json(); })
-            .then(function (data) { currentUsername = data.username; });
+        // Logged-in state is already known server-side (see index() in
+        // web/app.py, which this template is included into) -- no need to
+        // round-trip to /me just to ask again, and no race with a popup
+        // opening before that fetch would have resolved.
+        var currentUsername = {{ current_user | tojson }};
 
         // Shared by both marker popups (centered on that detection) and the
         // empty-map popup (centered on the clicked point) -- the only
@@ -564,11 +592,88 @@
         // "meaningful area" threshold.
         map.on('zoomend', updateHistoryButtonVisibility);
         updateHistoryButtonVisibility();
+
+        // City search: debounced search-as-you-type against /towns/search
+        // (cached server-side, see web/app.py -- the same city name gets
+        // searched over and over across everyone typing it), zooming the
+        // map to whichever result gets picked. Same debounce/stale-request
+        // pattern as the city-alert search on /notify -- see subscribe.html.
+        var CITY_ZOOM_LEVEL = 9;
+        var citySearchTimer = null;
+        var citySearchToken = 0;
+        var searchInput = document.getElementById('map-search-input');
+        var searchResults = document.getElementById('map-search-results');
+
+        function clearCitySearchResults() {
+            searchResults.innerHTML = '';
+        }
+
+        function goToCity(town) {
+            var latlng = L.latLng(town.latitude, town.longitude);
+            map.flyTo(latlng, CITY_ZOOM_LEVEL);
+
+            var label = [town.name, town.admin1_code, town.country_code].filter(Boolean).join(', ');
+            L.popup().setLatLng(latlng).setContent('<strong>' + label + '</strong>').openOn(map);
+        }
+
+        searchInput.addEventListener('input', function (event) {
+            var query = event.target.value.trim();
+
+            window.clearTimeout(citySearchTimer);
+            clearCitySearchResults();
+            if (!query) {
+                return;
+            }
+
+            citySearchTimer = window.setTimeout(function () {
+                var token = ++citySearchToken;
+                fetch('/towns/search?q=' + encodeURIComponent(query), { credentials: 'same-origin' })
+                    .then(function (response) { return response.json(); })
+                    .then(function (towns) {
+                        if (token !== citySearchToken) {
+                            return; // a newer keystroke's search has already superseded this one
+                        }
+                        clearCitySearchResults();
+                        towns.forEach(function (town) {
+                            var label = [town.name, town.admin1_code, town.country_code].filter(Boolean).join(', ');
+                            var item = document.createElement('li');
+                            item.textContent = label;
+                            item.addEventListener('click', function () {
+                                searchInput.value = label;
+                                clearCitySearchResults();
+                                goToCity(town);
+                            });
+                            searchResults.appendChild(item);
+                        });
+                    });
+            }, 250);
+        });
+
+        // Enter jumps to the top result instead of requiring a click, and
+        // clicking anywhere outside the results list dismisses it.
+        searchInput.addEventListener('keydown', function (event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                var first = searchResults.querySelector('li');
+                if (first) {
+                    first.click();
+                }
+            }
+        });
+        document.addEventListener('click', function (event) {
+            if (!document.getElementById('map-search').contains(event.target)) {
+                clearCitySearchResults();
+            }
+        });
     }
 </script>
 {% endblock %}
 {% block content %}
 <div id="map-controls">
+    <div id="map-search">
+        <input type="text" id="map-search-input" placeholder="Search for a city…" autocomplete="off" maxlength="100">
+        <ul id="map-search-results"></ul>
+    </div>
     <label for="show-all-readings">
         <input type="checkbox" id="show-all-readings">
         Show all readings (including low confidence)

--- a/web/templates/subscribe.html
+++ b/web/templates/subscribe.html
@@ -32,19 +32,48 @@
         </fieldset>
     </form>
     <p id="subscribe-status"></p>
+
+    <h2>...or a whole city</h2>
+    <p>
+        Prefer not to pick a point? Subscribe to a city instead &mdash;
+        by default you'll be matched whenever a detection's nearest city
+        (from a <a href="https://www.geonames.org/">GeoNames</a> lookup) is
+        the one you picked. Set a radius below to match by distance from
+        the city's own point instead, which also catches detections whose
+        nearest city happened to resolve to somewhere else nearby.
+    </p>
+
+    <form id="city-subscribe-form" style="display: none" autocomplete="off">
+        <fieldset>
+            <label for="city-subscribe-search">City</label>
+            <input type="text" id="city-subscribe-search" placeholder="Start typing a city name…" minlength="1" maxlength="100">
+            <ul id="city-subscribe-results"></ul>
+            <input type="hidden" id="city-subscribe-geoname-id" required>
+
+            <label for="city-subscribe-radius">Radius (miles, optional)</label>
+            <input type="number" id="city-subscribe-radius" name="radius_miles" step="any" min="1" max="500" placeholder="Exact city only">
+
+            <input type="submit" value="Notify me" disabled>
+        </fieldset>
+    </form>
+    <p id="city-subscribe-status"></p>
     <p><a href="/manage">Manage your existing subscriptions</a></p>
 </div>
 
+<style>
+    #city-subscribe-results { list-style: none; padding: 0; margin: 0.25rem 0; max-width: 22rem; }
+    #city-subscribe-results li { padding: 0.25rem 0.5rem; cursor: pointer; }
+    #city-subscribe-results li:hover { background: #eef1f4; }
+</style>
+
 <script>
-    // Logged-in state comes from the session cookie set by /login -- no
-    // credentials to collect on this page, `fetch` just sends the cookie
-    // along automatically for same-origin requests.
-    fetch('/me', { credentials: 'same-origin' })
-        .then(function (response) { return response.json(); })
-        .then(function (data) {
-            var target = data.username ? 'subscribe-form' : 'subscribe-logged-out';
-            document.getElementById(target).style.display = '';
-        });
+    // Logged-in state is already known server-side (see notify_page in
+    // web/app.py) -- no need to round-trip to /me just to ask again.
+    var currentUsername = {{ current_user | tojson }};
+    document.getElementById(currentUsername ? 'subscribe-form' : 'subscribe-logged-out').style.display = '';
+    if (currentUsername) {
+        document.getElementById('city-subscribe-form').style.display = '';
+    }
 
     document.getElementById('subscribe-form').addEventListener('submit', function (event) {
         event.preventDefault();
@@ -78,6 +107,95 @@
                     + payload.radius_miles + ' miles of that point on future reloads.';
                 form.reset();
                 form.radius_miles.value = 25;
+            })
+            .catch(function (err) {
+                status.textContent = 'Could not save that subscription: ' + err.message;
+            });
+    });
+
+    // Debounced search-as-you-type against /towns/search -- a fresh
+    // keystroke cancels whatever lookup was still in flight for the
+    // previous one, so a slow response for "spring" can't clobber the
+    // results for "springfield" typed a moment later.
+    var citySearchTimer = null;
+    var citySearchToken = 0;
+
+    document.getElementById('city-subscribe-search').addEventListener('input', function (event) {
+        var query = event.target.value.trim();
+        var results = document.getElementById('city-subscribe-results');
+        var submitButton = document.getElementById('city-subscribe-form').querySelector('input[type=submit]');
+
+        document.getElementById('city-subscribe-geoname-id').value = '';
+        submitButton.disabled = true;
+
+        window.clearTimeout(citySearchTimer);
+        results.innerHTML = '';
+        if (!query) {
+            return;
+        }
+
+        citySearchTimer = window.setTimeout(function () {
+            var token = ++citySearchToken;
+            fetch('/towns/search?q=' + encodeURIComponent(query), { credentials: 'same-origin' })
+                .then(function (response) { return response.json(); })
+                .then(function (towns) {
+                    if (token !== citySearchToken) {
+                        return; // a newer keystroke's search has already superseded this one
+                    }
+                    results.innerHTML = '';
+                    towns.forEach(function (town) {
+                        var label = [town.name, town.admin1_code, town.country_code].filter(Boolean).join(', ');
+                        var item = document.createElement('li');
+                        item.textContent = label;
+                        item.addEventListener('click', function () {
+                            document.getElementById('city-subscribe-search').value = label;
+                            document.getElementById('city-subscribe-geoname-id').value = town.geoname_id;
+                            submitButton.disabled = false;
+                            results.innerHTML = '';
+                        });
+                        results.appendChild(item);
+                    });
+                });
+        }, 250);
+    });
+
+    document.getElementById('city-subscribe-form').addEventListener('submit', function (event) {
+        event.preventDefault();
+
+        var status = document.getElementById('city-subscribe-status');
+        var geonameId = document.getElementById('city-subscribe-geoname-id').value;
+        if (!geonameId) {
+            status.textContent = 'Pick a city from the search results first.';
+            return;
+        }
+
+        var radiusInput = document.getElementById('city-subscribe-radius');
+        var radiusMiles = radiusInput.value ? parseFloat(radiusInput.value) : null;
+
+        status.textContent = 'Saving…';
+
+        fetch('/city-subscribers', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ geoname_id: parseInt(geonameId, 10), radius_miles: radiusMiles })
+        })
+            .then(function (response) {
+                if (!response.ok) {
+                    return response.json().then(function (body) {
+                        throw new Error(body.detail || ('Request failed: ' + response.status));
+                    });
+                }
+                return response.json();
+            })
+            .then(function (data) {
+                status.textContent = 'Subscribed (id ' + data.id + '). ' + (
+                    radiusMiles
+                        ? 'You\'ll be matched against fires within ' + radiusMiles + ' miles of that city\'s point.'
+                        : 'You\'ll be matched against fires whose nearest city is the one you picked.'
+                );
+                document.getElementById('city-subscribe-form').reset();
+                document.getElementById('city-subscribe-geoname-id').value = '';
             })
             .catch(function (err) {
                 status.textContent = 'Could not save that subscription: ' + err.message;


### PR DESCRIPTION
## Summary
- City subscriptions can now optionally set a `radius_miles`, matching by distance from the city's own point instead of requiring an exact nearest-city resolution.
- Alert-area labels (point and city subscriptions) are now editable after creation via inline fields on `/manage`.

## Details
- `city_subscribers`: nullable `radius_miles` column — `NULL` preserves the original exact-nearest-city match; setting it switches to distance-from-city-point matching.
- `notify.py`: radius-based city subscriptions matched by great-circle distance from the city's point, so they aren't limited to detections whose resolved nearest city happens to be this one.
- `web/app.py`: `POST /city-subscribers` accepts `radius_miles`; new `PATCH /city-subscribers/{id}/radius` to set/clear it later; `PATCH /subscribers|city-subscribers/{id}/label` to rename an alert area.
- `subscribe.html` / `manage.html`: optional radius field on the city subscribe form, inline-editable label/radius cells on `/manage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)